### PR TITLE
New configuration and view to support a warning message for users wit…

### DIFF
--- a/conf/intercept/warning-intercept-config.xml
+++ b/conf/intercept/warning-intercept-config.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:c="http://www.springframework.org/schema/c"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+                           http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd"
+                           
+       default-init-method="initialize"
+       default-destroy-method="destroy">
+
+    <!--
+    The map keys are the names of view templates to render if the condition evaluates to true.
+    
+    The values are of type Pair<Predicate<ProfileRequestContext>,Duration>. The condition determines whether
+    the warning is displayed, and the duration is the interval between warnings.
+    -->
+    <util:map id="shibboleth.warning.ConditionMap">
+        <entry key="google-shared-warning">
+            <bean parent="shibboleth.Pair">
+                <constructor-arg index="0">
+                    <bean id="uw.WarningIntercept"
+                        class="edu.washington.idp.intercept.impl.WarningIntercept"
+                        p:webClient-ref="uw.UWHttpClient"
+                        p:gwsUrlbase = "%{idp.uw.slack-gws-urlbase}"
+                        p:targetRpid = "google.com"
+                        p:groupId = "warning_google-shared"
+                    />
+                </constructor-arg>
+                <constructor-arg index="1">
+                    <bean class="java.time.Duration" factory-method="parse" c:_0="P7D" />
+                </constructor-arg>
+            </bean>
+        </entry>
+ 
+        <!--
+        <entry key="warn-one">
+            <bean parent="shibboleth.Pair">
+                <constructor-arg index="0">
+                    <bean parent="shibboleth.Conditions.TRUE" />
+                </constructor-arg>
+                <constructor-arg index="1">
+                    <bean class="java.time.Duration" factory-method="parse" c:_0="PT8H" />
+                </constructor-arg>
+            </bean>
+        </entry>
+        <entry key="warn-two">
+            <bean parent="shibboleth.Pair">
+                <constructor-arg index="0">
+                    <bean parent="shibboleth.Conditions.TRUE" />
+                </constructor-arg>
+                <constructor-arg index="1">
+                    <bean class="java.time.Duration" factory-method="parse" c:_0="PT0S" />
+                </constructor-arg>
+            </bean>
+        </entry>
+        -->
+    </util:map>
+    
+</beans>

--- a/conf/relying-party.xml
+++ b/conf/relying-party.xml
@@ -190,7 +190,7 @@
                      p:encryptAssertions="false"
                      p:securityConfiguration-ref="LegacySecurityConfig" 
                      p:nameIDFormatPrecedence="#{{'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'}}"
-                     p:postAuthenticationFlows="#{{'google-check'}}"
+                     p:postAuthenticationFlows="#{{'google-check', 'warning'}}"
                      />
                 </list>
             </property>

--- a/views/intercept/google-shared-warning.vm
+++ b/views/intercept/google-shared-warning.vm
@@ -1,0 +1,133 @@
+##
+## Velocity Template for Display 2FARequiredSoonNotification view-state
+##
+## Velocity context will contain the following properties
+## flowExecutionUrl - the form action location
+## flowRequestContext - the Spring Web Flow RequestContext
+## flowExecutionKey - the SWF execution key (this is built into the flowExecutionUrl)
+## profileRequestContext - root of context tree
+## authenticationContext - context with authentication request information
+## authenticationErrorContext - context with login error state
+## authenticationWarningContext - context with login warning state
+## ldapResponseContext - context with LDAP state (if using native LDAP)
+## rpUIContext - the context with SP UI information from the metadata
+## extendedAuthenticationFlows - collection of "extended" AuthenticationFlowDescriptor objects
+## passwordPrincipals - contents of the shibboleth.authn.Password.PrincipalOverride bean
+## encoder - HTMLEncoder class
+## request - HttpServletRequest
+## response - HttpServletResponse
+## environment - Spring Environment object for property resolution
+## custom - arbitrary object injected by deployer
+##
+#set ($rpContext = $profileRequestContext.getSubcontext('net.shibboleth.idp.profile.context.RelyingPartyContext'))
+#set ($username = $authenticationContext.getSubcontext('net.shibboleth.idp.authn.context.UsernamePasswordContext', true).getUsername())
+#set ($passwordEnabled = false)
+#if (!$passwordPrincipals or $passwordPrincipals.isEmpty() or $authenticationContext.isAcceptable($passwordPrincipals))
+  #set ($passwordEnabled = true)
+#end
+##
+<!DOCTYPE html>
+<html>
+  	<head>
+    	<meta charset="utf-8">
+<link rel="stylesheet" type="text/css" href="/css/opensans.css" media="screen, handheld" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<title>UW NetID sign-in</title>
+  <meta name="description" content="">
+  <meta name="author" content="">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="cleartype" content="on">
+<link rel="stylesheet" type="text/css" href="/css/weblogin-global.css" media="screen, handheld" />
+  <link rel="stylesheet" type="text/css" href="/css/weblogin-enhanced.css" media="screen  and (min-width: 40.5em)" />
+  <!--[if (lt IE 9)&(!IEMobile)]>
+  <link rel="stylesheet" type="text/css" href="/css/weblogin-enhanced.css" />
+  <![endif]-->
+
+
+  	</head>
+
+
+<body>
+
+  <h1 class="visuallyhidden">UW NetID sign-in</h1>
+
+  <div id="container">
+    <div id="main" role="main">
+
+      <h2 class="visuallyhidden" aria-flowto="weblogin_warning">Login</h2>
+      <div class="form">
+          <div><img src="/img/weblogin.png" height="57" width="198" alt="" aria-hidden="true"></div>
+
+          <form name="idpgooglesplashintercept" id="idpgooglesplashinterceptdiv" method="POST" action="$flowExecutionUrl" autocomplete="off">
+
+          <p/><strong><span data-contrast="auto">WARNING</span></strong>
+          <span data-contrast="auto">: The UW NetID account you are logging in with is either a</span>
+          <a target="_blank" href="https://itconnect.uw.edu/tools-services-support/access-authentication/uw-netids/about-uw-netids/shared-uw-netids/">
+              <span data-contrast="none"><span data-ccp-char="">Shared UW NetID</span></span></a>
+          <span data-contrast="auto">with a UW Google account, or a personal UW NetID that is the</span>
+          <a target="_blank" href="https://uwnetid.washington.edu/manage/?shared">
+              <span data-contrast="none"><span data-ccp-char="">owner or admin of a Shared UW NetID</span></span></a>
+          <span data-contrast="auto">with a UW Google account.</span><p/>
+          
+          <p/><span data-contrast="auto">On 8/29/23, UW Google accounts and data will be deleted for all Shared UW NetIDs.</span><p/>
+
+          <p/>
+          <a target="_blank" href="https://itconnect.uw.edu/tools-services-support/software-computers/productivity-platforms/google-productivity-platform/uw-google-changes-project/alternatives-shared-uw-netids/">
+              <span data-contrast="none"><span data-ccp-char="">
+              Click here to learn about migrating data and alternatives to UW Google for Shared UW NetIDs
+              </span></span>
+          </a><p/>
+          
+          <p/><span data-contrast="auto">By selecting CONTINUE, you acknowledge that you are aware of the upcoming
+          deletion of all UW Google accounts and data for Shared UW NetIDs on 8/29/23.</span></p>
+          
+          <p/><a target="_blank" href="https://provision.uw.edu/">
+              <span data-contrast="none"><span data-ccp-char="">
+              Click here to view the Shared UW NetIDs you own that have UW Google services
+              </span></span>
+          </a><p/>
+
+          <p><span data-contrast="auto">For more information on the UW Google Changes project,</span>
+          <a target="_blank" href="https://itconnect.uw.edu/tools-services-support/software-computers/productivity-platforms/google-productivity-platform/uw-google-changes-project/">
+          <span data-contrast="none"><span data-ccp-char="">click here</span></span></a>.<p/>
+
+            <ul class="submit">
+              <li><input type="submit" id="submit_button" name="_eventId_proceed" value="Continue"></li>
+            </ul>
+
+          </form>
+
+        </div>
+
+        <h2 class="visuallyhidden">UW NetID Help</h2>
+        <div class="sidebar">
+
+                <!-- <h3 style="margin-top:0;">UW NetID Help</h3> -->
+
+            <ul class="links">
+                <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
+                <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
+                <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
+                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
+                <li style="height: 30px"></li>
+                <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
+            </ul>
+
+        </div>
+        <div id="weblogin_warning" class="warning">
+
+            <p>Sign in reduces how often you have to reauthenticate to access UW resources.</p>
+
+            <p>Learn how to <a href="http://itconnect.uw.edu/security/uw-netids/weblogin/#logout">sign out</a> at the end of your browsing session.</p>
+
+            <p class="copyright"><span class="copyright-links"><a href="http://www.washington.edu/online/privacy">PRIVACY</a> | <a href="http://www.washington.edu/online/terms">TERMS</a></span></p>
+
+         </div>
+
+
+    </div> <!--end main -->
+  </div> <!-- end container -->
+
+
+ 	</body>
+</html>


### PR DESCRIPTION
…h shared netids accessing Google.

Added one new view with the warning message, one new config file to configure the warning module, and a one-line change to relying_party.xml to enable the warning flow for the google.com relying party.
Note that I put the relying party name and groupId (subgroup of our idpauthz groups) in the warning config instead of as properties in idp.properties. I think this is appropriate because these are only used by this specific intercept.
