### PR TITLE
Removed the "Obtain a UW NetID" link from all views.

### DIFF
--- a/views/crnselect.vm
+++ b/views/crnselect.vm
@@ -81,7 +81,6 @@ function _clear_screen() {
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/disusered.vm
+++ b/views/disusered.vm
@@ -63,7 +63,6 @@
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/duo-soon.vm
+++ b/views/duo-soon.vm
@@ -97,7 +97,6 @@
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/duo.vm
+++ b/views/duo.vm
@@ -135,7 +135,6 @@ Using your '$duo_username' Duo identity.
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/entrust.vm
+++ b/views/entrust.vm
@@ -101,7 +101,6 @@ href="https://identity.uw.edu/2fa" target="_blank">identity.uw.edu/2fa</a>.</div
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/google-redirect.vm
+++ b/views/google-redirect.vm
@@ -94,7 +94,6 @@
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/login.vm
+++ b/views/login.vm
@@ -149,7 +149,6 @@ window.onload = function() {
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/needduo.vm
+++ b/views/needduo.vm
@@ -64,7 +64,6 @@
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/no-slack.vm
+++ b/views/no-slack.vm
@@ -75,7 +75,6 @@
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>

--- a/views/noworkday.vm
+++ b/views/noworkday.vm
@@ -63,7 +63,6 @@
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/account-recovery//">Learn about account recovery options</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/about-uw-netids/">Learn about UW NetIDs</a></li>
                 <li><a href="http://itconnect.uw.edu/security/uw-netids/weblogin/">Learn about UW NetID sign-in</A></li>
-                <li><a href="https://uwnetid.washington.edu/newid/">Obtain a UW NetID</a></li>
                 <li style="height: 30px"></li>
                 <li><a href="http://itconnect.uw.edu/help/">Need help?</a></li>
             </ul>


### PR DESCRIPTION
Removed a link from 10 different views, including the main login page and a number of post-authentication views with the same general structure. This is to resolve Issue #33 Remove the Obtain a UW NetID link from the idp login screen.
