### PR TITLE
Relying party updates

### DIFF
--- a/conf/relying-party.xml
+++ b/conf/relying-party.xml
@@ -267,9 +267,15 @@
                 <ref bean="SAML2.Logout" />
                 <ref bean="Liberty.SSOS" />
                 <bean parent="OIDC.SSO"
-                p:accessTokenLifetime="PT1H"
-                p:refreshTokenLifetime="PT168H"
-                 />
+                    p:accessTokenLifetime="PT1H"
+                    p:refreshTokenTimeout="PT168H"
+                    p:refreshTokenChainLifetime="PT168H"
+                />
+                <bean parent="OAUTH2.Token"
+                    p:accessTokenLifetime="PT1H"
+                    p:refreshTokenTimeout="PT168H"
+                    p:refreshTokenChainLifetime="PT168H"
+                />
                 <bean parent="OIDC.UserInfo"/>
                 <bean parent="OAUTH2.Revocation"/>
                </list>

--- a/conf/relying-party.xml
+++ b/conf/relying-party.xml
@@ -98,7 +98,7 @@
         </bean>
 
         <!-- needing signed assertions -->
-        <bean parent="RelyingPartyByName" c:relyingPartyIds="#{ {'https://az1.qualtrics.com','https://saml.enplug.com','https://uweducation.communityforce.com','https://uweducationstaging.communityforce.com','https://login.apogeenet.net/sp','https://pvs.education.uw.edu','https://app.yodeck.com/api/v1/account/metadata/'} }">
+        <bean parent="RelyingPartyByName" c:relyingPartyIds="#{ {'https://az1.qualtrics.com','https://saml.enplug.com','https://uweducation.communityforce.com','https://uweducationstaging.communityforce.com','https://login.apogeenet.net/sp','https://pvs.education.uw.edu','https://app.yodeck.com/api/v1/account/metadata/','https://sso.pitchbook.com/sso/saml/sp/metadata'} }">
             <property name="profileConfigurations">
                 <list>
                     <bean parent="SAML2.SSO"


### PR DESCRIPTION


Two minor updates to satisfy two operational issues. This file contains custom configurations for specific relying parties.
1. Added the site pitchbook.com to the list of RPs needing signed assertions as requested by REQ7742723. Per this request, the customer will validate once the change has been put into production.
2. Updated the configuration for the oidc/myuw RP. This RP needs a longer timeout for the refresh token. The latest version of the OIDC plugin (which we deployed in July) changed the configuration directives causing the prior configuration to be ignored. This update fixes the configuration as recommended by Shibboleth support and validated by the myuw support team in our eval domain.

