### PR TITLE
Minor OIDC config updates

### DIFF
--- a/conf/oidc-filter.xml
+++ b/conf/oidc-filter.xml
@@ -6,13 +6,20 @@
                       urn:mace:shibboleth:2.0:afp:oidc http://shibboleth.net/schema/oidc/shibboleth-afp-oidc.xsd">
 
 
+    <!-- This file controls the data attributes released to OIDC clients.
+         Currently this is manually edited until we can build an SPRegistry-controlled
+         process to generate this file.
+         
+         There are two sections of this file. The top section controls the attributes released
+         based on OIDC scopes. The bottom section contains rules for specifc relying parties.
+    -->
+
+    <!-- This section contains one attribute rule for each supported OIDC scope,
+         as specified by the value of the PolicyRequirementRule at the beginning of each policy.
+    -->
+
     <AttributeFilterPolicy id="OPENID_SCOPE">
 	<PolicyRequirementRule xsi:type="oidc:OIDCScope" value="openid" />
-	<!--
-	<AttributeRule attributeID="subject">
-	    <PermitValueRule xsi:type="ANY" />
-	</AttributeRule>
-	-->
         <AttributeRule attributeID="subject-public">
             <PermitValueRule xsi:type="ANY" />
         </AttributeRule>
@@ -20,13 +27,6 @@
             <PermitValueRule xsi:type="ANY" />
         </AttributeRule>
     </AttributeFilterPolicy> 
-
-    <AttributeFilterPolicy id="OPENID_urizen">
-        <PolicyRequirementRule xsi:type="Requester" value="oidc/urizen.s.uw.edu"/>
-        <AttributeRule attributeID="preferredFirst">
-            <PermitValueRule xsi:type="ANY" />
-        </AttributeRule>
-    </AttributeFilterPolicy>
 
     <AttributeFilterPolicy id="OPENID_SCOPE_EMAIL">
         <PolicyRequirementRule xsi:type="oidc:OIDCScope" value="email" />
@@ -105,6 +105,20 @@
     </AttributeFilterPolicy>
 
 
+    <!-- All policies below here apply to specific relying parties (RPs),
+         as defined by the value, or value set, of the PolicyRequirementRule.
+
+         Most of these policies define the subset of UW Groups released to each RP.
+         The naming convention for such policies is "OPENID_MEMBER_OF_" plus an indicator for the RP.
+    -->
+
+    <AttributeFilterPolicy id="OPENID_urizen">
+        <PolicyRequirementRule xsi:type="Requester" value="oidc/urizen.s.uw.edu"/>
+        <AttributeRule attributeID="preferredFirst">
+            <PermitValueRule xsi:type="ANY" />
+        </AttributeRule>
+    </AttributeFilterPolicy>
+
     <AttributeFilterPolicy id="OPENID_MEMBER_OF_SAND">
         <PolicyRequirementRule xsi:type="AND">
            <Rule xsi:type="Requester" value="oidc/gws.sandbox.iam.s.uw.edu" />
@@ -145,10 +159,13 @@
            <Rule xsi:type="Requester" value="oidc/research-eval.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research-int.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research-dev.ui.oris.washington.edu" />
+           <Rule xsi:type="Requester" value="oidc/research.washington.edu" />
+           <Rule xsi:type="Requester" value="oidc/eval.research.washington.edu" />
+           <Rule xsi:type="Requester" value="oidc/int.research.washington.edu" />
         </PolicyRequirementRule>
         <AttributeRule attributeID="gws_groups">
            <PermitValueRule xsi:type="OR">
-            <Rule xsi:type="ValueRegex" regex="urn:mace:washington.edu:groups:u_oris_provs_.*"/>
+            <Rule xsi:type="ValueRegex" regex="urn:mace:washington.edu:groups:u_oris_privs_.*"/>
            </PermitValueRule>
         </AttributeRule>
     </AttributeFilterPolicy>

--- a/conf/oidc.properties
+++ b/conf/oidc.properties
@@ -52,7 +52,7 @@ idp.signing.oidc.rsa.enc.key = %{idp.home}/credentials/idp-encryption-rsa.jwk
 
 # shibboleth.ClientInformationResolverService properties
 #idp.service.clientinfo.failFast = false
-#idp.service.clientinfo.checkInterval = PT0S
+idp.service.clientinfo.checkInterval = PT15M
 #idp.service.clientinfo.resources = shibboleth.ClientInformationResolverResources
 
 # Special claim handling rules
@@ -83,5 +83,5 @@ idp.oidc.subject.sourceAttribute = uwRegID
 #idp.oidc.jwksuri.fetchInterval = PT30M
 
 # Lower bound on the next file refresh from the time calculated based on the previous attempt for OP's own metadata (configuration-flow).
-#idp.oidc.config.minRefreshDelay = PT5M
-#idp.oidc.config.maxRefreshDelay = PT4H
+idp.oidc.config.minRefreshDelay = PT5M
+idp.oidc.config.maxRefreshDelay = PT15M


### PR DESCRIPTION
Primary change is to oidc-filter.xml to add three new OIDC clients under the ORIS rule that defines the UW groups sent to those clients.
Also fixed that rule so the correct groups will be released.
Also added comments to that file to explain what is in the file, and moved one of the policies for better organization.

In the oidc.properties file, set some properties that control how oidc configuration changes are automatically reloaded. The target is that the Shibboleth OIDC configuration and the OIDC metadata (in metadata/oidc-client.json) will be checked for updates every 15 minutes and changes reloaded.
The OIDC attribute filter rules (in oidc-filter.xml) are not automatically checked for changes. When changes are made, a script is run to make Shibboleth reload the filter configuration.
