### PR TITLE
Idp 5.1.4

### DIFF
--- a/conf/examples/oidc-attribute-resolver.xml
+++ b/conf/examples/oidc-attribute-resolver.xml
@@ -6,8 +6,12 @@
                         urn:mace:shibboleth:2.0:resolver:oidc http://shibboleth.net/schema/oidc/shibboleth-attribute-encoder-oidc.xsd">
 
     <!--
-    Some of the examples assume conf/attributes/oidc-claim-rules.xml is loaded
-    into the registry service.
+    Some of the examples assume conf/attributes/oidc-claim-rules.xml is
+    loaded into the registry service.
+    
+    Additionally, the "sub" claim examples below all assume that the file
+    including them is also loaded into that service to process the
+    AttributeEncoder elements shown in these examples.
     -->
 
     <!--
@@ -29,12 +33,14 @@
     <AttributeDefinition id="subjectPublic" xsi:type="Scoped" scope="%{idp.scope}"
             activationConditionRef="shibboleth.oidc.Conditions.PublicRequired">
         <InputAttributeDefinition ref="uid" />
+        <!-- Only works if you load the containing file into the registry service. -->
         <AttributeEncoder xsi:type="oidc:OIDCScopedString" name="sub" />
     </AttributeDefinition>
 
     <AttributeDefinition id="subjectPairwise" xsi:type="Scoped" scope="%{idp.scope}"
             activationConditionRef="shibboleth.oidc.Conditions.PairwiseRequired">
         <InputDataConnector ref="computedSubjectId" attributeNames="subjectId"/>
+        <!-- Only works if you load the containing file into the registry service. -->
         <AttributeEncoder xsi:type="oidc:OIDCScopedString" name="sub" />
     </AttributeDefinition>
 

--- a/conf/global.xml
+++ b/conf/global.xml
@@ -18,6 +18,12 @@
       p:userFile="/data/local/idp/conf/authn/dynamic-mfa.txt"
       />
 
+<!-- resolver for OIDC client secrets -->
+<util:list id="shibboleth.oidc.ClientSecretValueResolvers">
+	<bean parent="shibboleth.oidc.PropertiesClientSecretValueResolver"
+		p:resource="%{idp.home}/credentials/client-secrets.properties" />
+</util:list>
+
 <!-- http client for group attr resolver -->
 <bean id="uw.HttpClient"  parent="shibboleth.HttpClientFactory" lazy-init="true"
         p:connectionDisregardTLSCertificate="%{idp.httpclient.connectionDisregardTLSCertificate:false}"

--- a/local-bin/py-requirements.txt
+++ b/local-bin/py-requirements.txt
@@ -1,6 +1,6 @@
 psycopg2-binary==2.9.10
 lxml==5.3.0
-jinja2==3.1.5
+jinja2==3.1.6
 pep8==1.7.1
 requests==2.32.3
 pyyaml==6.0.2


### PR DESCRIPTION
Three minor updates.
1. conf/global.xml - added support for client secrets in a separate credentials file. This will have no impact until we move OIDC metadata from the current JSON format to the new SAML file format.
2. conf/examples/oidc-attribute-resolver.xml: Shibboleth updated this example configuration file.
3. local-bin/py-requirements: patched one Python library that had a medium security vulnerability.