### PR TITLE
OIDC metadata updates

### DIFF
--- a/conf/oidc-filter.xml
+++ b/conf/oidc-filter.xml
@@ -159,6 +159,7 @@
            <Rule xsi:type="Requester" value="oidc/research-eval.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research-int.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research-dev.ui.oris.washington.edu" />
+           <Rule xsi:type="Requester" value="oidc/research-poc.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/eval.research.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/int.research.washington.edu" />

--- a/local-bin/getMetadataFilename.sh
+++ b/local-bin/getMetadataFilename.sh
@@ -1,0 +1,25 @@
+#/bin/bash
+#
+# Client metadata is stored in XML files. The filename is defined as the SHA-1 hash of the entityId (see spreg_processor.py).
+# This script is an alternate way to generate the filename matching a particular client.
+# The script takes one argument, which is the entityId (or client_id, for OIDC clients).
+# Example:
+# ./getMetadataFilename.sh "https://urizen.s.uw.edu/shibboleth"
+
+if [ $# -lt 1 ]
+then
+  echo "Usage: getMetadataFilename.sh <entityId>"
+  exit 1
+fi
+ENTITY_ID=$1
+
+# Note carefully the -n argument to the echo command. This suppresses the line feed so that the hash is computed
+# only on the supplied value. Without this argument, the line feed would be included which would create a
+# completely different hash value. Also, sha1sum prints a useless value after the hash, so the awk command
+# returns only the first field which is the actual hash value.
+
+HASH=$(echo -n $ENTITY_ID | sha1sum | awk '{print $1}')
+
+
+# Print the filename, which is the hash value with '.xml' appended.
+echo ${HASH}.xml


### PR DESCRIPTION
Two changes:
1. Minor update to the oidc filter file. Added a new site to the rule that releases groups to the set of research sites.
2. Added a new helper script to calculate the name of a metadata file from the entityId.
