### PR TITLE
Simple mystery solved

### DIFF
--- a/conf/attribute-resolver.xml
+++ b/conf/attribute-resolver.xml
@@ -63,6 +63,7 @@
         <InputDataConnector ref="personreg" attributeNames="uwRegID" />
         <AttributeEncoder xsi:type="SAML1String" name="urn:mace:washington.edu:dir:attribute-def:uwRegID" />
         <AttributeEncoder xsi:type="SAML2String" name="urn:oid:1.2.840.113994.200.24" friendlyName="uwRegID" />
+	<AttributeEncoder xsi:type="oidc:OIDCString" name="uwRegID" />
     </AttributeDefinition>
 
 


### PR DESCRIPTION
Who knew you needed an OIDC AttributeEncoder to deliver a claim to an OIDC client? Duh!