### PR TITLE
oidc/eval.research.washington.edu/research, plus a couple of deletions

### DIFF
--- a/conf/oidc-filter.xml
+++ b/conf/oidc-filter.xml
@@ -159,14 +159,13 @@
 
     <AttributeFilterPolicy id="OPENID_MEMBER_OF_ORIS">
         <PolicyRequirementRule xsi:type="OR">
-           <Rule xsi:type="Requester" value="oidc/myresearch-int.ui.oris.washington.edu" />
-           <Rule xsi:type="Requester" value="oidc/myresearch.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research-eval.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research-int.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research-dev.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research-poc.ui.oris.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/research.washington.edu" />
            <Rule xsi:type="Requester" value="oidc/eval.research.washington.edu" />
+           <Rule xsi:type="Requester" value="oidc/eval.research.washington.edu/research" />
            <Rule xsi:type="Requester" value="oidc/int.research.washington.edu" />
         </PolicyRequirementRule>
         <AttributeRule attributeID="gws_groups">


### PR DESCRIPTION
the myresearch* clients are gone; no evidence in xml configs or oidc-client.json. Just forgot to clear them out of oidc-filter when I was rationalizing the clients.