### PR TITLE
Refresh metadata

### DIFF
--- a/local-bin/refresh_uw.sh
+++ b/local-bin/refresh_uw.sh
@@ -21,7 +21,7 @@ export LD_LIBRARY_PATH=/usr/local/pgsql-12.2/lib
 
 {
 
-md_pre="`date +%s -r ${root}/metadata/UW-rp-metadata.xml`"
+md_pre="`date +%s -r ${root}/rp-metadata`"
 filter_pre="`date +%s -r ${root}/conf/rp-filter.xml`"
 nameid_pre="`date +%s -r ${root}/conf/saml-nameid-exceptions.xml`"
 attrs_pre="`date +%s -r ${root}/conf/attribute-resolver-activators.xml`"
@@ -33,11 +33,10 @@ uparg=
 python spreg_processor.py $uparg -v
 
 # if rp-metadata changed, notify idp
-md_post="`date +%s -r ${root}/metadata/UW-rp-metadata.xml`"
+md_post="`date +%s -r ${root}/rp-metadata`"
 (( md_post > md_pre + 60 )) && {
    echo "notify idp of metadata change"
-   ## this causes too much overhead.. reloading incommon metadata
-   ## ${root}/bin/reload-service.sh -id shibboleth.MetadataResolverService
+   ${root}/local-bin/reload_metadata
 }
 
 filter_post="`date +%s -r ${root}/conf/rp-filter.xml`"
@@ -54,22 +53,22 @@ attrs_post="`date +%s -r ${root}/conf/attribute-resolver-activators.xml`"
  
 (( nameid_post > nameid_pre + 60 )) && {
    echo "notify idp of nameid exceptions change"
-   ${root}/bin/reload-service.sh -id shibboleth.NameIdentifierGenerationService
+   ${root}/local-bin/reload_nameid
 }
 
 (( attrs_post > attrs_pre + 60 )) && {
    echo "notify idp of attribute resolver activators change"
-   ${root}/bin/reload-service.sh -id shibboleth.AttributeResolverService
+   ${root}/local-bin/reload_attributeresolver
 }
 
 (( filter_post > filter_pre + 60 )) && {
    echo "notify idp of attribute filter change"
-   ${root}/bin/reload-service.sh -id shibboleth.AttributeFilterService
+   ${root}/local-bin/reload_filter
 }
 
 (( auto_post > auto_pre + 60 )) && {
    echo "notify idp of auto rps change"
-   ${root}/bin/reload-service.sh -id shibboleth.RelyingPartyResolverService
+   ${root}/bin/reload_relyingparty
 }
 
 rm -f /www/refresh_uw/lock

--- a/local-bin/reload_nameid
+++ b/local-bin/reload_nameid
@@ -1,0 +1,3 @@
+SCRIPT_DIR=$(dirname $0)
+. $SCRIPT_DIR/setJavaHome.sh
+/data/local/idp/bin/reload-service.sh -id shibboleth.NameIdentifierGenerationService


### PR DESCRIPTION
Two modifications to the refresh_uw.sh script that loads content from SPRegistry.
First, if new metadata was loaded, force reload all metadata. This was previously disabled because it was taking too long with the gigantic single file, but now it works because all files are distinct and they can be loaded one at a time.
Second, all the reload actions were updated to call the relevant scripts in local-bin, which set the correct Java version before performing the reload action. All such loads would have failed before because they would have been using an unsupported Java version. This required adding a new reload script following the same pattern as the others.
